### PR TITLE
Set the content type of requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Cache gems

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -2,7 +2,7 @@ module MagicBell
   module ApiOperations
     def get(url, options = {})
       defaults = { headers: default_headers }
-      response = HTTParty.get(url, defaults.merge(options))
+      response = HTTParty.get(url, options.merge(defaults))
       raise_http_error_unless_2xx_response(response)
 
       response
@@ -10,7 +10,7 @@ module MagicBell
 
     def post(url, options = {})
       defaults = { headers: default_headers }
-      response = HTTParty.post(url, defaults.merge(options))
+      response = HTTParty.post(url, options.merge(defaults))
       raise_http_error_unless_2xx_response(response)
 
       response
@@ -18,7 +18,7 @@ module MagicBell
 
     def put(url, options = {})
       defaults = { headers: default_headers }
-      response = HTTParty.put(url, defaults.merge(options))
+      response = HTTParty.put(url, options.merge(defaults))
       raise_http_error_unless_2xx_response(response)
 
       response

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -3,7 +3,7 @@ module MagicBell
     def get(url, options = {})
       response = HTTParty.get(
         url,
-        options.merge(headers: authentication_headers)
+        options.merge(headers: default_headers)
       )
       raise_http_error_unless_2xx_response(response)
 
@@ -13,7 +13,7 @@ module MagicBell
     def post(url, options = {})
       response = HTTParty.post(
         url,
-        options.merge(headers: authentication_headers)
+        options.merge(headers: default_headers)
       )
       raise_http_error_unless_2xx_response(response)
 
@@ -23,7 +23,7 @@ module MagicBell
     def put(url, options = {})
       response = HTTParty.put(
         url,
-        options.merge(headers: authentication_headers)
+        options.merge(headers: default_headers)
       )
       raise_http_error_unless_2xx_response(response)
 

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -1,39 +1,40 @@
 module MagicBell
   module ApiOperations
     def get(url, options = {})
-      response = HTTParty.get(
-        url,
-        options.merge(headers: default_headers)
-      )
+      defaults = { headers: default_headers }
+      response = HTTParty.get(url, defaults.merge(options))
       raise_http_error_unless_2xx_response(response)
 
       response
     end
 
     def post(url, options = {})
-      response = HTTParty.post(
-        url,
-        options.merge(headers: default_headers)
-      )
+      defaults = { headers: default_headers }
+      response = HTTParty.post(url, defaults.merge(options))
       raise_http_error_unless_2xx_response(response)
 
       response
     end
 
     def put(url, options = {})
-      response = HTTParty.put(
-        url,
-        options.merge(headers: default_headers)
-      )
+      defaults = { headers: default_headers }
+      response = HTTParty.put(url, defaults.merge(options))
       raise_http_error_unless_2xx_response(response)
 
       response
+    end
+
+    protected
+
+    def default_headers
+      authentication_headers.merge({ "Content-Type" => "application/json", "Accept"=> "application/json" })
     end
 
     private
 
     def raise_http_error_unless_2xx_response(response)
       return if response.success?
+
       e = MagicBell::Client::HTTPError.new
       e.response_status = response.code
       e.response_headers = response.headers.to_h

--- a/lib/magicbell/api_resource.rb
+++ b/lib/magicbell/api_resource.rb
@@ -79,7 +79,7 @@ module MagicBell
       response = @client.post(
         create_url,
         body: { name => attributes }.to_json,
-        headers: authentication_headers
+        headers: extra_headers
       )
       parse_response(response)
 
@@ -90,7 +90,7 @@ module MagicBell
       response = @client.put(
         url,
         body: new_attributes.to_json,
-        headers: authentication_headers
+        headers: extra_headers
       )
       parse_response(response)
 
@@ -99,8 +99,8 @@ module MagicBell
 
     protected
 
-    def authentication_headers
-      MagicBell.authentication_headers
+    def extra_headers
+      {}
     end
 
     private

--- a/lib/magicbell/client.rb
+++ b/lib/magicbell/client.rb
@@ -21,6 +21,10 @@ module MagicBell
       MagicBell::User.new(client, "email" => email)
     end
 
+    def default_headers
+      authentication_headers.merge("Content-Type" => "application/json")
+    end
+
     def authentication_headers
       MagicBell.authentication_headers
     end

--- a/lib/magicbell/client.rb
+++ b/lib/magicbell/client.rb
@@ -21,10 +21,6 @@ module MagicBell
       MagicBell::User.new(client, "email" => email)
     end
 
-    def default_headers
-      authentication_headers.merge("Content-Type" => "application/json")
-    end
-
     def authentication_headers
       MagicBell.authentication_headers
     end

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -10,6 +10,7 @@ describe MagicBell::Client do
       "X-MAGICBELL-API-KEY" => api_key,
       "X-MAGICBELL-API-SECRET" => api_secret,
       "Content-Type" => "application/json",
+      "Accept" => "application/json",
     }
   }
   let(:user_authentication_headers) { headers.merge("X-MAGICBELL-USER-EMAIL" => user_email) }
@@ -35,6 +36,7 @@ describe MagicBell::Client do
           }
         }.to_json
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 201, body: "{}")
+
         magicbell = MagicBell::Client.new
         magicbell.create_notification(
           title: "Welcome to Muziboo",
@@ -56,6 +58,7 @@ describe MagicBell::Client do
           }
         }.to_json
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 201, body: "{}")
+
         magicbell = MagicBell::Client.new
         magicbell.create_notification(
           title: "Welcome to Muziboo",
@@ -74,10 +77,12 @@ describe MagicBell::Client do
           }
         }.to_json
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422)
+
         magicbell = MagicBell::Client.new
         expect do
           magicbell.create_notification(title: "Welcome to Muziboo")
         end.to raise_error(MagicBell::Client::HTTPError)
+
         begin
           magicbell.create_notification(title: "Welcome to Muziboo")
         rescue MagicBell::Client::HTTPError => e
@@ -102,8 +107,10 @@ describe MagicBell::Client do
           "id" => "notification_id"
         }
       }.to_json
+
       stub_request(:get, notification_url).with(headers: user_authentication_headers).and_return(status: 200, body: response_body)
       user_notification = user.find_notification(notification_id)
+
       stub_request(:post, notification_read_url).with(headers: user_authentication_headers).and_return(status: 204)
       user_notification.mark_as_read
     end
@@ -162,6 +169,7 @@ describe MagicBell::Client do
       user = magicbell.user_with_email(user_email)
       mark_all_notifications_as_read_request = stub_request(:post, notifications_read_url).with(headers: user_authentication_headers).and_return(status: 204)
       user.mark_all_notifications_as_read
+
       assert_requested(mark_all_notifications_as_read_request)
     end
   end
@@ -174,6 +182,7 @@ describe MagicBell::Client do
       user = magicbell.user_with_email(user_email)
       mark_all_notification_as_seen_request = stub_request(:post, notifications_seen_url).with(headers: user_authentication_headers).and_return(status: 204)
       user.mark_all_notifications_as_seen
+
       assert_requested(mark_all_notification_as_seen_request)
     end
   end
@@ -193,6 +202,7 @@ describe MagicBell::Client do
         "X-MAGICBELL-API-KEY" => api_key,
         "X-MAGICBELL-API-SECRET" => api_secret,
         "Content-Type" => "application/json",
+        "Accept" => "application/json",
       }
       body = {
         "notification" => {

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -8,7 +8,8 @@ describe MagicBell::Client do
   let(:headers) {
     {
       "X-MAGICBELL-API-KEY" => api_key,
-      "X-MAGICBELL-API-SECRET" => api_secret
+      "X-MAGICBELL-API-SECRET" => api_secret,
+      "Content-Type" => "application/json",
     }
   }
   let(:user_authentication_headers) { headers.merge("X-MAGICBELL-USER-EMAIL" => user_email) }
@@ -181,14 +182,17 @@ describe MagicBell::Client do
     it "is also configurable in an initializer" do
       ENV.delete("MAGICBELL_API_KEY")
       ENV.delete("MAGICBELL_API_SECRET")
+      WebMock.enable!
+
       MagicBell.configure do |config|
         config.api_key = api_key
         config.api_secret = api_secret
       end
-      WebMock.enable!
+
       headers = {
         "X-MAGICBELL-API-KEY" => api_key,
         "X-MAGICBELL-API-SECRET" => api_secret,
+        "Content-Type" => "application/json",
       }
       body = {
         "notification" => {
@@ -199,6 +203,7 @@ describe MagicBell::Client do
         }
       }.to_json
       stub_request(:post, "#{api_host}/notifications").with(headers: headers, body: body).and_return(status: 201, body: "{}")
+
       magicbell = MagicBell::Client.new
       magicbell.create_notification(
         title: "Welcome to Muziboo",


### PR DESCRIPTION
When the payload contains the `%` character, the request fails. The `Content-Type` header has to be set