### PR TITLE
Display api errors on catching exception

### DIFF
--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -41,11 +41,13 @@ module MagicBell
       e.response_status = response.code
       e.response_headers = response.headers.to_h
       e.response_body = response.body
-      body = JSON.parse(response.body)
-      e.errors = body["errors"]
-      e.errors.each do |error, index|
-        puts "#{error["suggestion"].red}"
-        puts "#{error["help_link"].blue.on_white}"
+      unless e.response_body.nil? || e.response_body.empty?
+        body = JSON.parse(response.body)
+        e.errors = body["errors"]
+        e.errors.each do |error, index|
+          puts "#{error["suggestion"].red}"
+          puts "#{error["help_link"].blue.on_white}"
+        end
       end
       raise e
     end

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -41,6 +41,7 @@ module MagicBell
       e.response_status = response.code
       e.response_headers = response.headers.to_h
       e.response_body = response.body
+      e.errors = []
       unless e.response_body.nil? || e.response_body.empty?
         body = JSON.parse(response.body)
         e.errors = body["errors"]

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -1,6 +1,5 @@
 require 'json'
 require 'colorize'
-require 'pp'
 module MagicBell
   module ApiOperations
     def get(url, options = {})

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -1,3 +1,6 @@
+require 'json'
+require 'colorize'
+require 'pp'
 module MagicBell
   module ApiOperations
     def get(url, options = {})
@@ -34,11 +37,17 @@ module MagicBell
 
     def raise_http_error_unless_2xx_response(response)
       return if response.success?
-
+      
       e = MagicBell::Client::HTTPError.new
       e.response_status = response.code
       e.response_headers = response.headers.to_h
       e.response_body = response.body
+      body = JSON.parse(response.body)
+      e.errors = body["errors"]
+      e.errors.each do |error, index|
+        puts "#{error["suggestion"].red}"
+        puts "#{error["help_link"].blue.on_white}"
+      end
       raise e
     end
   end

--- a/lib/magicbell/client.rb
+++ b/lib/magicbell/client.rb
@@ -3,7 +3,8 @@ module MagicBell
     class HTTPError < StandardError
       attr_accessor :response_status,
                     :response_headers,
-                    :response_body
+                    :response_body,
+                    :errors
     end
 
     include ApiOperations

--- a/lib/magicbell/version.rb
+++ b/lib/magicbell/version.rb
@@ -1,3 +1,3 @@
 module MagicBell
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/magicbell.gemspec
+++ b/magicbell.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty'
   s.add_dependency 'activesupport'
-
+  s.add_dependency 'colorize'
+  
   s.add_development_dependency "actionmailer"
   s.add_development_dependency "rspec", '~> 3.9'
   s.add_development_dependency "webmock"


### PR DESCRIPTION
Opening this PR to resolve
https://magicbell.productboard.com/roadmap/2566106-release-roadmap/features/7496637/detail/expanded
The PR does the following two things
1. adds api errors to MagicBell Error
2. displays the error suggestions
![image](https://user-images.githubusercontent.com/82579109/115201292-cfa34880-a112-11eb-9837-94460c7e1b98.png)


