### PR TITLE
Enable per project configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ and install the gem
 bundle install
 ```
 
+## Configuration
+
+### Global configuration
 The gem will automatically pick your MagicBell project's API Key and API Secret from the `MAGICBELL_API_KEY` and `MAGICBELL_API_SECRET` environment variables. Alternatively, provide the API Key and API Secret in an initializer
 
 ```
@@ -45,6 +48,17 @@ MagicBell.configure do |config|
 end
 ```
 
+### Per project configuration
+If you integrate more than one MagicBell project into your application, you may want to use different sets of API key and API client, per project.
+To achieve this, you can create a `MagicBell::Client` object, with a configuration that will override the global configuration.
+
+```ruby
+  magicbell_client = MagicBell::Client.new(
+    api_key: "your_project_magicbell_api_key",
+    api_secret: "your_project_magicbell_api_secret"
+  )
+```
+If a set of API key and API secret are not provided to the client, the global configuration will be used.
 ## API Wrapper
 
 This gem makes it easy to interact with MagicBell's REST API https://developer.magicbell.io/reference from Ruby
@@ -195,9 +209,17 @@ end
 
 ### Calculate HMAC
 
+#### Using API secret from global configuration
 ```
 user_email = "joe@example.com"
 hmac = MagicBell.hmac(user_email)
+```
+
+#### Using a specific API secret
+```ruby
+user_email = "joe@example.com"
+
+hmac = MagicBell.hmac(user_email, client_api_secret: 'your_api_secret')
 ```
 
 See https://developer.magicbell.io/docs/turn-on-hmac-authentication for more information on turning on HMAC Authentication for your MagicBell Project

--- a/lib/magicbell.rb
+++ b/lib/magicbell.rb
@@ -54,9 +54,9 @@ module MagicBell
     end
 
     # Calculate HMAC for user's email
-    def hmac(message)
+    def hmac(message, client_api_secret: nil)
       digest = sha256_digest
-      secret = api_secret
+      secret = client_api_secret || api_secret
 
       Base64.encode64(OpenSSL::HMAC.digest(digest, secret, message)).strip
     end

--- a/lib/magicbell.rb
+++ b/lib/magicbell.rb
@@ -46,10 +46,10 @@ module MagicBell
       @config = Config.new
     end
 
-    def authentication_headers
+    def authentication_headers(client_api_key: nil, client_api_secret: nil)
       {
-        "X-MAGICBELL-API-KEY" => api_key,
-        "X-MAGICBELL-API-SECRET" => api_secret
+        "X-MAGICBELL-API-KEY" => client_api_key || api_key,
+        "X-MAGICBELL-API-SECRET" => client_api_secret || api_secret
       }
     end
 

--- a/lib/magicbell.rb
+++ b/lib/magicbell.rb
@@ -55,16 +55,7 @@ module MagicBell
 
     # Calculate HMAC for user's email
     def hmac(message)
-      digest = sha256_digest
-      secret = api_secret
-
-      Base64.encode64(OpenSSL::HMAC.digest(digest, secret, message)).strip
-    end
-
-    private
-
-    def sha256_digest
-      OpenSSL::Digest::Digest.new('sha256')
+      MagicBell::Client.new(api_key: api_key, api_secret: api_secret).hmac(message)
     end
   end
 end

--- a/lib/magicbell.rb
+++ b/lib/magicbell.rb
@@ -54,9 +54,9 @@ module MagicBell
     end
 
     # Calculate HMAC for user's email
-    def hmac(message, client_api_secret: nil)
+    def hmac(message)
       digest = sha256_digest
-      secret = client_api_secret || api_secret
+      secret = api_secret
 
       Base64.encode64(OpenSSL::HMAC.digest(digest, secret, message)).strip
     end

--- a/lib/magicbell/client.rb
+++ b/lib/magicbell/client.rb
@@ -9,6 +9,11 @@ module MagicBell
 
     include ApiOperations
 
+    def initialize(api_key: nil, api_secret: nil)
+      @api_key = api_key
+      @api_secret = api_secret
+    end
+
     def create_notification(notification_attributes)
       MagicBell::Notification.create(self, notification_attributes)
     end
@@ -23,7 +28,7 @@ module MagicBell
     end
 
     def authentication_headers
-      MagicBell.authentication_headers
+      MagicBell.authentication_headers(client_api_key: @api_key, client_api_secret: @api_secret)
     end
   end
 end

--- a/lib/magicbell/client.rb
+++ b/lib/magicbell/client.rb
@@ -30,5 +30,17 @@ module MagicBell
     def authentication_headers
       MagicBell.authentication_headers(client_api_key: @api_key, client_api_secret: @api_secret)
     end
+
+    def hmac(message)
+      secret = @api_secret || MagicBell.api_secret
+
+      Base64.encode64(OpenSSL::HMAC::digest(sha256_digest, secret, message)).strip
+    end
+
+    private
+
+    def sha256_digest
+      OpenSSL::Digest::Digest.new('sha256')
+    end
   end
 end

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -46,7 +46,7 @@ describe MagicBell::Client do
         )
       end
     end
-    
+
     context "when recipient is identified by external_id" do
       it "creates a notification" do
         body = {
@@ -255,6 +255,27 @@ describe MagicBell::Client do
           email: "john@example.com"
         }]
       )
+    end
+  end
+
+  describe "API key and API secret configuration" do
+    let(:client_api_key) { 'client_api_key' }
+    let(:client_api_secret) { 'client_api_secret' }
+
+    context "No API key and API secret provided" do
+      it "keeps the global headers" do
+        magicbell = MagicBell::Client.new
+
+        expect(magicbell.authentication_headers).to eq("X-MAGICBELL-API-KEY" => api_key, "X-MAGICBELL-API-SECRET" => api_secret)
+      end
+    end
+
+    context "API key and API key provided" do
+      it "overrides the global headers with the project headers" do
+        magicbell = MagicBell::Client.new(api_key: client_api_key, api_secret: client_api_secret)
+
+        expect(magicbell.authentication_headers).to eq("X-MAGICBELL-API-KEY" => client_api_key, "X-MAGICBELL-API-SECRET" => client_api_secret)
+      end
     end
   end
 end

--- a/spec/magicbell_spec.rb
+++ b/spec/magicbell_spec.rb
@@ -2,18 +2,18 @@ describe MagicBell do
   let(:api_key) { "dummy_api_key" }
   let(:api_secret) { "dummy_api_secret" }
 
+  before do
+    MagicBell.configure do |config|
+      config.api_key = api_key
+      config.api_secret = api_secret
+    end
+  end
+
+  after do
+    MagicBell.reset_config
+  end
+
   describe ".configure" do
-    before do
-      MagicBell.configure do |config|
-        config.api_key = api_key
-        config.api_secret = api_secret
-      end
-    end
-
-    after do
-      MagicBell.reset_config
-    end
-
     it "configures the gem" do
       expect(MagicBell.api_key).to eq(api_key)
       expect(MagicBell.api_secret).to eq(api_secret)
@@ -26,16 +26,14 @@ describe MagicBell do
   end
 
   describe "#hmac" do
-    let(:api_secret) { "dummy_api_secret" }
     let(:user_email) { "john@example.com" }
+    let(:magicbell) { MagicBell::Client.new }
 
-    it "calculates the hmac for the given string" do
-      ENV["MAGICBELL_API_SECRET"] = "dummy_api_secret"
+    it "calls the hmac method on MagicBell::Client object" do
+      expect(MagicBell::Client).to receive(:new).with(api_key: MagicBell.api_key, api_secret: MagicBell.api_secret).and_return(magicbell)
+      expect(magicbell).to receive(:hmac).with(user_email)
 
-      hmac = MagicBell.hmac(user_email)
-      # expect(MagicBell.hmac(user_email)).to eq("6rsCIEh9sNFbxMO4NQfBMG88eXWMufPPUubCTggCfnE=")
-      sha256_digest = OpenSSL::Digest.new('sha256')
-      expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, api_secret, user_email))
+      MagicBell.hmac(user_email)
     end
   end
 end

--- a/spec/magicbell_spec.rb
+++ b/spec/magicbell_spec.rb
@@ -29,26 +29,13 @@ describe MagicBell do
     let(:api_secret) { "dummy_api_secret" }
     let(:user_email) { "john@example.com" }
 
-    context "Using the API secret from the global configuration" do
-      it "calculates the hmac for the given string" do
-        ENV["MAGICBELL_API_SECRET"] = "dummy_api_secret"
+    it "calculates the hmac for the given string" do
+      ENV["MAGICBELL_API_SECRET"] = "dummy_api_secret"
 
-        hmac = MagicBell.hmac(user_email)
-        # expect(MagicBell.hmac(user_email)).to eq("6rsCIEh9sNFbxMO4NQfBMG88eXWMufPPUubCTggCfnE=")
-        sha256_digest = OpenSSL::Digest.new('sha256')
-        expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, api_secret, user_email))
-      end
-    end
-
-    context "Using a specific API secret" do
-      let(:client_api_secret) { 'your_client_api_secret' }
-
-      it "calculates the hmac for the given string" do
-        hmac = MagicBell.hmac(user_email, client_api_secret: client_api_secret)
-
-        sha256_digest = OpenSSL::Digest.new('sha256')
-        expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, client_api_secret, user_email))
-      end
+      hmac = MagicBell.hmac(user_email)
+      # expect(MagicBell.hmac(user_email)).to eq("6rsCIEh9sNFbxMO4NQfBMG88eXWMufPPUubCTggCfnE=")
+      sha256_digest = OpenSSL::Digest.new('sha256')
+      expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, api_secret, user_email))
     end
   end
 end

--- a/spec/magicbell_spec.rb
+++ b/spec/magicbell_spec.rb
@@ -29,13 +29,26 @@ describe MagicBell do
     let(:api_secret) { "dummy_api_secret" }
     let(:user_email) { "john@example.com" }
 
-    it "calculates the hmac for the given string" do
-      ENV["MAGICBELL_API_SECRET"] = "dummy_api_secret"
+    context "Using the API secret from the global configuration" do
+      it "calculates the hmac for the given string" do
+        ENV["MAGICBELL_API_SECRET"] = "dummy_api_secret"
 
-      hmac = MagicBell.hmac(user_email)
-      # expect(MagicBell.hmac(user_email)).to eq("6rsCIEh9sNFbxMO4NQfBMG88eXWMufPPUubCTggCfnE=")
-      sha256_digest = OpenSSL::Digest.new('sha256')
-      expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, api_secret, user_email))
+        hmac = MagicBell.hmac(user_email)
+        # expect(MagicBell.hmac(user_email)).to eq("6rsCIEh9sNFbxMO4NQfBMG88eXWMufPPUubCTggCfnE=")
+        sha256_digest = OpenSSL::Digest.new('sha256')
+        expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, api_secret, user_email))
+      end
+    end
+
+    context "Using a specific API secret" do
+      let(:client_api_secret) { 'your_client_api_secret' }
+
+      it "calculates the hmac for the given string" do
+        hmac = MagicBell.hmac(user_email, client_api_secret: client_api_secret)
+
+        sha256_digest = OpenSSL::Digest.new('sha256')
+        expect(base64_decode(hmac)).to eq(OpenSSL::HMAC.digest(sha256_digest, client_api_secret, user_email))
+      end
     end
   end
 end


### PR DESCRIPTION
- Allow setting optional API key and API secret per MagicBell::Client object
- Allow HMAC calculation, using a specific API secret
- Keep global configuration as a default