### PR TITLE
Cover non 2xx with no "errors"

### DIFF
--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -44,7 +44,7 @@ module MagicBell
       e.errors = []
       unless e.response_body.nil? || e.response_body.empty?
         body = JSON.parse(response.body)
-        e.errors = body["errors"]
+        e.errors = body["errors"] || []
         e.errors.each do |error, index|
           puts "#{error["suggestion"].red}"
           puts "#{error["help_link"].blue.on_white}"

--- a/lib/magicbell/api_operations.rb
+++ b/lib/magicbell/api_operations.rb
@@ -44,7 +44,7 @@ module MagicBell
       e.errors = []
       unless e.response_body.nil? || e.response_body.empty?
         body = JSON.parse(response.body)
-        e.errors = body["errors"] || []
+        e.errors = body["errors"].is_a?(Array) ? body["errors"] : []
         e.errors.each do |error, index|
           puts "#{error["suggestion"].red}"
           puts "#{error["help_link"].blue.on_white}"

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -162,6 +162,32 @@ describe MagicBell::Client do
           expect(exception_thrown.errors.length).to eq(0)
         end
       end
+
+      context("and there is a response body with with a nonarray errors block") do
+        let(:response_body) do
+          {
+            "errors" => "testing 1234"
+          }.to_json
+        end
+
+        before do
+          stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
+        end
+
+        it "raises and displays an error" do
+          exception_thrown = nil
+          begin
+            magicbell.create_notification(title: title)
+          rescue MagicBell::Client::HTTPError => e
+            exception_thrown = e
+          end
+
+          expect(exception_thrown.response_status).to eq(422)
+          expect(exception_thrown.response_headers).to eq({})
+          expect(exception_thrown.response_body).to eq(response_body)
+          expect(exception_thrown.errors.length).to eq(0)
+        end
+      end
     end
   end
 

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -74,12 +74,15 @@ describe MagicBell::Client do
     end
 
     context "API response was not a 2xx response" do
-      it "raises an error" do
-        body = {
+      let(:body) do
+        {
           "notification" => {
             "title" => "Welcome to Muziboo"
           }
         }.to_json
+      end
+
+      it "raises an error" do
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422)
 
         magicbell = MagicBell::Client.new
@@ -95,13 +98,8 @@ describe MagicBell::Client do
         expect(exception_thrown.response_headers).to eq({})
         expect(exception_thrown.response_body).to eq("")
       end
-      it "raises and displays an error" do
-        body = {
-          "notification" => {
-            "title" => "Welcome to Muziboo"
-          }
-        }.to_json
 
+      it "raises and displays an error" do
         response_body = {
           "errors"=>
           [

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -104,31 +104,38 @@ describe MagicBell::Client do
         end
       end
 
-      it "raises and displays an error" do
-        response_body = {
-          "errors"=>
-          [
-            {
-              "code" => "api_secret_not_provided",
-              "suggestion" => "Please provide the 'X-MAGICBELL-API-SECRET' header containing your MagicBell project's API secret. Alternatively, if you intend to use MagicBell's API in JavaScript in your web application's frontend, please provide the 'X-MAGICBELL-USER-EMAIL' header containing a user's email and the 'X-MAGICBELL-USER-HMAC' containing the user's HMAC.",
-              "message" => "API Secret not provided",
-              "help_link" => "https://developer.magicbell.io/reference#authentication"
-            }
-          ]
-        }.to_json
-        stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
-
-        exception_thrown = nil
-        begin
-          magicbell.create_notification(title: title)
-        rescue MagicBell::Client::HTTPError => e
-          exception_thrown = e
+      context("and there is a response body with an errors block") do
+        let(:response_body) do
+          {
+            "errors"=>
+            [
+              {
+                "code" => "api_secret_not_provided",
+                "suggestion" => "Please provide the 'X-MAGICBELL-API-SECRET' header containing your MagicBell project's API secret. Alternatively, if you intend to use MagicBell's API in JavaScript in your web application's frontend, please provide the 'X-MAGICBELL-USER-EMAIL' header containing a user's email and the 'X-MAGICBELL-USER-HMAC' containing the user's HMAC.",
+                "message" => "API Secret not provided",
+                "help_link" => "https://developer.magicbell.io/reference#authentication"
+              }
+            ]
+          }.to_json
         end
 
-        expect(exception_thrown.response_status).to eq(422)
-        expect(exception_thrown.response_headers).to eq({})
-        expect(exception_thrown.response_body).to eq(response_body)
-        expect(exception_thrown.errors.length).to eq(1)
+        before do
+          stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
+        end
+
+        it "raises and displays an error" do
+          exception_thrown = nil
+          begin
+            magicbell.create_notification(title: title)
+          rescue MagicBell::Client::HTTPError => e
+            exception_thrown = e
+          end
+
+          expect(exception_thrown.response_status).to eq(422)
+          expect(exception_thrown.response_headers).to eq({})
+          expect(exception_thrown.response_body).to eq(response_body)
+          expect(exception_thrown.errors.length).to eq(1)
+        end
       end
     end
   end

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -83,17 +83,17 @@ describe MagicBell::Client do
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422)
 
         magicbell = MagicBell::Client.new
-        expect do
-          magicbell.create_notification(title: "Welcome to Muziboo")
-        end.to raise_error(MagicBell::Client::HTTPError)
 
+        exception_thrown = nil
         begin
           magicbell.create_notification(title: "Welcome to Muziboo")
         rescue MagicBell::Client::HTTPError => e
-          expect(e.response_status).to eq(422)
-          expect(e.response_headers).to eq({})
-          expect(e.response_body).to eq("")
+          exception_thrown = e
         end
+
+        expect(exception_thrown.response_status).to eq(422)
+        expect(exception_thrown.response_headers).to eq({})
+        expect(exception_thrown.response_body).to eq("")
       end
       it "raises and displays an error" do
         body = {
@@ -116,18 +116,18 @@ describe MagicBell::Client do
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
 
         magicbell = MagicBell::Client.new
-        expect do
-          magicbell.create_notification(title: "Welcome to Muziboo")
-        end.to raise_error(MagicBell::Client::HTTPError)
 
+        exception_thrown = nil
         begin
           magicbell.create_notification(title: "Welcome to Muziboo")
         rescue MagicBell::Client::HTTPError => e
-          expect(e.response_status).to eq(422)
-          expect(e.response_headers).to eq({})
-          expect(e.response_body).to eq(response_body)
-          expect(e.errors.length).to eq(1)
+          exception_thrown = e
         end
+
+        expect(exception_thrown.response_status).to eq(422)
+        expect(exception_thrown.response_headers).to eq({})
+        expect(exception_thrown.response_body).to eq(response_body)
+        expect(exception_thrown.errors.length).to eq(1)
       end
     end
   end

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -137,6 +137,31 @@ describe MagicBell::Client do
           expect(exception_thrown.errors.length).to eq(1)
         end
       end
+
+      context("and there is a response body with no errors block") do
+        let(:response_body) do
+          {
+          }.to_json
+        end
+
+        before do
+          stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
+        end
+
+        it "raises and displays an error" do
+          exception_thrown = nil
+          begin
+            magicbell.create_notification(title: title)
+          rescue MagicBell::Client::HTTPError => e
+            exception_thrown = e
+          end
+
+          expect(exception_thrown.response_status).to eq(422)
+          expect(exception_thrown.response_headers).to eq({})
+          expect(exception_thrown.response_body).to eq(response_body)
+          expect(exception_thrown.errors.length).to eq(0)
+        end
+      end
     end
   end
 

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -95,6 +95,7 @@ describe MagicBell::Client do
           exception_thrown = e
         end
 
+        expect(exception_thrown).to not_be_nil()
         expect(exception_thrown.response_status).to eq(422)
         expect(exception_thrown.response_headers).to eq({})
         expect(exception_thrown.response_body).to eq("")
@@ -121,6 +122,7 @@ describe MagicBell::Client do
           exception_thrown = e
         end
 
+        expect(exception_thrown).to not_be_nil()
         expect(exception_thrown.response_status).to eq(422)
         expect(exception_thrown.response_headers).to eq({})
         expect(exception_thrown.response_body).to eq(response_body)

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -74,10 +74,11 @@ describe MagicBell::Client do
     end
 
     context "API response was not a 2xx response" do
+      let(:title) { "Welcome to Muziboo" }
       let(:body) do
         {
           "notification" => {
-            "title" => "Welcome to Muziboo"
+            "title" => title
           }
         }.to_json
       end
@@ -89,7 +90,7 @@ describe MagicBell::Client do
 
         exception_thrown = nil
         begin
-          magicbell.create_notification(title: "Welcome to Muziboo")
+          magicbell.create_notification(title: title)
         rescue MagicBell::Client::HTTPError => e
           exception_thrown = e
         end
@@ -117,7 +118,7 @@ describe MagicBell::Client do
 
         exception_thrown = nil
         begin
-          magicbell.create_notification(title: "Welcome to Muziboo")
+          magicbell.create_notification(title: title)
         rescue MagicBell::Client::HTTPError => e
           exception_thrown = e
         end

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -74,6 +74,7 @@ describe MagicBell::Client do
     end
 
     context "API response was not a 2xx response" do
+
       let(:title) { "Welcome to Muziboo" }
       let(:body) do
         {
@@ -82,11 +83,10 @@ describe MagicBell::Client do
           }
         }.to_json
       end
+      let(:magicbell) { MagicBell::Client.new }
 
       it "raises an error" do
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422)
-
-        magicbell = MagicBell::Client.new
 
         exception_thrown = nil
         begin
@@ -113,8 +113,6 @@ describe MagicBell::Client do
           ]
         }.to_json
         stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
-
-        magicbell = MagicBell::Client.new
 
         exception_thrown = nil
         begin

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -139,10 +139,7 @@ describe MagicBell::Client do
       end
 
       context("and there is a response body with no errors block") do
-        let(:response_body) do
-          {
-          }.to_json
-        end
+        let(:response_body) { {}.to_json }
 
         before do
           stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)
@@ -164,11 +161,7 @@ describe MagicBell::Client do
       end
 
       context("and there is a response body with with a nonarray errors block") do
-        let(:response_body) do
-          {
-            "errors" => "testing 1234"
-          }.to_json
-        end
+        let(:response_body) { { "errors" => "testing 1234" }.to_json }
 
         before do
           stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422, body: response_body)

--- a/spec/magicbell/client_spec.rb
+++ b/spec/magicbell/client_spec.rb
@@ -85,20 +85,23 @@ describe MagicBell::Client do
       end
       let(:magicbell) { MagicBell::Client.new }
 
-      it "raises an error" do
-        stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422)
-
-        exception_thrown = nil
-        begin
-          magicbell.create_notification(title: title)
-        rescue MagicBell::Client::HTTPError => e
-          exception_thrown = e
+      context("and there is no response body") do
+        before do
+          stub_request(:post, notifications_url).with(headers: headers, body: body).and_return(status: 422)
         end
 
-        expect(exception_thrown).to not_be_nil()
-        expect(exception_thrown.response_status).to eq(422)
-        expect(exception_thrown.response_headers).to eq({})
-        expect(exception_thrown.response_body).to eq("")
+        it "raises an error" do
+          exception_thrown = nil
+          begin
+            magicbell.create_notification(title: title)
+          rescue MagicBell::Client::HTTPError => e
+            exception_thrown = e
+          end
+
+          expect(exception_thrown.response_status).to eq(422)
+          expect(exception_thrown.response_headers).to eq({})
+          expect(exception_thrown.response_body).to eq("")
+        end
       end
 
       it "raises and displays an error" do
@@ -122,7 +125,6 @@ describe MagicBell::Client do
           exception_thrown = e
         end
 
-        expect(exception_thrown).to not_be_nil()
         expect(exception_thrown.response_status).to eq(422)
         expect(exception_thrown.response_headers).to eq({})
         expect(exception_thrown.response_body).to eq(response_body)


### PR DESCRIPTION
## Change description

I was poking around the library's tests and noticed I got an unexpected error when flipping http codes around.  

This PR includes some test refactoring, where I just consolidated some of the test arrangement so I could write the final two tests with a copy/paste of the previous.  I also took out calling the method twice to trap the exception, which may not be what you'd want.

Just throwing it out for fun, I don't think this is a serious issue and may not warrant the merge.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
