### PR TITLE
Use OpenSSL::Digest instead of OpenSSL::Digest::Digest

### DIFF
--- a/lib/magicbell/client.rb
+++ b/lib/magicbell/client.rb
@@ -41,7 +41,7 @@ module MagicBell
     private
 
     def sha256_digest
-      OpenSSL::Digest::Digest.new('sha256')
+      OpenSSL::Digest.new('sha256')
     end
   end
 end


### PR DESCRIPTION
## Change description

OpenSSL::Digest::Digest has been deprecated since before Ruby 2.0 (https://github.com/ruby/openssl/commit/5c20a4c014845b7e14860b594b634195697d456d).

OpenSSL::Digest should be used in place of OpenSSL::Digest::Digest

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes deprecation warning: `gems/magicbell-2.2.0/lib/magicbell/client.rb:44: warning: constant OpenSSL::Digest::Digest is deprecated`

## Checklists

### Development

- [ ] Lint rules pass locally
  - No reference to how to run linters locally, and no obvious included linters in codebase
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
  - No reference to security guidelines in README

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
